### PR TITLE
Allow health-checks to be performed only on new autoscaling group

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -47,3 +47,27 @@ How to run: `rake sample_4`
 | Green stack gets some traffic                            |   <img src="../docs/autocanary_80_20.png" height="150" /> |
 | Green stack gets more traffic                            |   <img src="../docs/autocanary_50_50.png" height="150" /> |
 | Rollback: All the traffic goes again to blue stack       |   <img src="../docs/autocanary_100_0.png" height="150" /> |
+
+## 5) Switch complete stacks at once and roll back when health check fails
+
+How to run: `rake sample_5`
+
+| Steps     |      |
+| :------------- | :------------- |
+| Initial state: All the traffic goes to blue stack                 |   <img src="../docs/autocanary_100_none.png" height="150" /> |
+| Green stack is created                                            |   <img src="../docs/autocanary_100_0.png" height="150" /> |
+| Green stack gets all the traffic. Blue stack will not be deleted  |   <img src="../docs/autocanary_0_100.png" height="150" />  |
+| The health check fails                                            |   <img src="../docs/autocanary_0_100.png" height="150" />  |
+| Rollback: All the traffic goes again to blue stack                |   <img src="../docs/autocanary_100_0.png" height="150" /> |
+
+## 6) Switch complete stacks at once and clean up when health check succeeds
+
+How to run: `rake sample_6`
+
+| Steps     |      |
+| :------------- | :------------- |
+| Initial state: All the traffic goes to blue stack                 |   <img src="../docs/autocanary_100_none.png" height="150" /> |
+| Green stack is created                                            |   <img src="../docs/autocanary_100_0.png" height="150" /> |
+| Green stack gets all the traffic. Blue stack will not be deleted  |   <img src="../docs/autocanary_0_100.png" height="150" />  |
+| The health check succeeds                                         |   <img src="../docs/autocanary_0_100.png" height="150" />  |
+| Blue stack will be deleted                                        |   <img src="../docs/autocanary_none_100.png" height="150" />  |

--- a/examples/Rakefile
+++ b/examples/Rakefile
@@ -76,6 +76,46 @@ task :sample_4 do
   client.deploy_stack(STACK_NAME, ASG_TEMPLATE, ASG_PARAMETER, TAGS, deployment_check)
 end
 
+desc 'switch complete stacks at once keeping and rollback after health check fails'
+task :sample_5 do
+  puts 'executing sample_5: switch complete stacks at once keeping and rollback after health check fails'
+
+  # 1) Create the base stack which includes at least the ELB
+  Stacker.create_or_update_stack(STACK_NAME, BASE_TEMPLATE, {}, nil, TAGS)
+
+  # 2) Create the stack which includes the ASG
+  client = AutoCanary24::Client.new({:keep_inactive_stack => true})
+  client.deploy_stack(STACK_NAME, ASG_TEMPLATE, ASG_PARAMETER, TAGS)
+
+  breaking_deployment_check = false
+
+  if breaking_deployment_check
+    client.cleanup_stack(STACK_NAME)
+  else
+    client.rollback_stack(STACK_NAME)
+  end
+end
+
+desc 'switch complete stacks at once keeping and clean up after health check succeeds'
+task :sample_6 do
+  puts 'executing sample_6: switch complete stacks at once keeping and clean up after health check succeeds'
+
+  # 1) Create the base stack which includes at least the ELB
+  Stacker.create_or_update_stack(STACK_NAME, BASE_TEMPLATE, {}, nil, TAGS)
+
+  # 2) Create the stack which includes the ASG
+  client = AutoCanary24::Client.new({:keep_inactive_stack => true})
+  client.deploy_stack(STACK_NAME, ASG_TEMPLATE, ASG_PARAMETER, TAGS)
+
+  successful_deployment_check = true
+
+  if successful_deployment_check
+    client.cleanup_stack(STACK_NAME)
+  else
+    client.rollback_stack(STACK_NAME)
+  end
+end
+
 task :cleanup do
   puts 'executing cleanup'
 

--- a/lib/autocanary24/canarystack.rb
+++ b/lib/autocanary24/canarystack.rb
@@ -82,6 +82,14 @@ module AutoCanary24
         .map{ |i| { instance_id: i[:instance_id] } }
     end
 
+    def is_stack_created?
+      begin
+        get_instance_ids
+      rescue
+        return false
+      end
+      true
+    end
 
     private
     def describe_asg(asg)

--- a/lib/autocanary24/canarystack.rb
+++ b/lib/autocanary24/canarystack.rb
@@ -32,7 +32,7 @@ module AutoCanary24
     def is_attached_to(elb)
       asg = get_autoscaling_group
       elbs = get_attached_loadbalancers(asg) unless asg.nil?
-      (!elbs.nil? && elbs.any? { |e| e.load_balancer_name == elb })
+      (!elbs.nil? && elbs.any? { |e| e.load_balancer_name == elb && e.state != "Removing" && e.state != "Removed" })
     end
 
     def attach_instances_to_elb_and_wait(elb, instances)

--- a/lib/autocanary24/client.rb
+++ b/lib/autocanary24/client.rb
@@ -60,13 +60,18 @@ module AutoCanary24
 
       old_stack = stacks[:stack_to_create]
 
-      delete_stack(old_stack.stack_name)
+      if old_stack.is_stack_created?
+        delete_stack(old_stack.stack_name)
+      end
     end
 
     private
     def attach_stack_to_create_and_detach_stack_to_delete(elb, stacks)
       write_log(stacks[:stack_to_create].stack_name, "Attach to ELB #{elb}")
-      stacks[:stack_to_create].attach_asg_to_elb_and_wait(elb)
+
+      if stacks[:stack_to_create].is_stack_created?
+        stacks[:stack_to_create].attach_asg_to_elb_and_wait(elb)
+      end
 
       unless stacks[:stack_to_delete].nil?
         write_log(stacks[:stack_to_delete].stack_name, "Detach from ELB #{elb}")

--- a/lib/autocanary24/client.rb
+++ b/lib/autocanary24/client.rb
@@ -20,10 +20,7 @@ module AutoCanary24
         elb = get_elb(parent_stack_name)
         raise "No ELB found in stack #{parent_stack_name}" if elb.nil?
 
-        blue_cs = get_canary_stack("#{parent_stack_name}-B")
-        green_cs = get_canary_stack("#{parent_stack_name}-G")
-
-        stacks = get_stacks_to_create_and_to_delete_for(blue_cs, green_cs, elb)
+        stacks = get_stacks_to_create_and_to_delete(parent_stack_name, elb)
 
         before_switch(stacks, template, parameters, parent_stack_name, tags)
 
@@ -44,8 +41,49 @@ module AutoCanary24
 
     end
 
+    def rollback_stack(parent_stack_name)
+      write_log(parent_stack_name,"Rolling back stack")
+
+      elb = get_elb(parent_stack_name)
+
+      stacks = get_stacks_to_create_and_to_delete(parent_stack_name, elb)
+
+      attach_stack_to_create_and_detach_stack_to_delete(elb, stacks)
+    end
+
+    def cleanup_stack(parent_stack_name)
+      write_log(parent_stack_name,"Cleaning up stack")
+
+      elb = get_elb(parent_stack_name)
+
+      stacks = get_stacks_to_create_and_to_delete(parent_stack_name, elb)
+
+      old_stack = stacks[:stack_to_create]
+
+      unless old_stack.nil?
+        delete_stack(old_stack.stack_name)
+      end
+    end
+
     private
-    def get_stacks_to_create_and_to_delete_for(blue_cs, green_cs, elb)
+    def attach_stack_to_create_and_detach_stack_to_delete(elb, stacks)
+      write_log(stacks[:stack_to_create].stack_name, "Attach to ELB #{elb}")
+      stacks[:stack_to_create].attach_asg_to_elb_and_wait(elb)
+
+      unless stacks[:stack_to_delete].nil?
+        write_log(stacks[:stack_to_delete].stack_name, "Detach from ELB #{elb}")
+        stacks[:stack_to_delete].detach_asg_from_elb_and_wait(elb)
+      end
+    end
+
+    def get_stacks_to_create_and_to_delete(parent_stack_name, elb)
+      blue_cs = get_canary_stack("#{parent_stack_name}-B")
+      green_cs = get_canary_stack("#{parent_stack_name}-G")
+
+      determine_stacks_to_create_and_to_delete_for(blue_cs, green_cs, elb)
+    end
+
+    def determine_stacks_to_create_and_to_delete_for(blue_cs, green_cs, elb)
 
       green_is_attached = green_cs.is_attached_to(elb)
       blue_is_attached = blue_cs.is_attached_to(elb)
@@ -139,13 +177,7 @@ module AutoCanary24
         end
       end
 
-      write_log(stacks[:stack_to_create].stack_name, "Attach to ELB #{elb}")
-      stacks[:stack_to_create].attach_asg_to_elb_and_wait(elb)
-
-      unless stacks[:stack_to_delete].nil?
-        write_log(stacks[:stack_to_delete].stack_name, "Detach from ELB #{elb}")
-        stacks[:stack_to_delete].detach_asg_from_elb_and_wait(elb)
-      end
+      attach_stack_to_create_and_detach_stack_to_delete(elb, stacks)
     end
 
     def rollback(stacks, elb, already_attached_instances, already_detached_instances)

--- a/lib/autocanary24/client.rb
+++ b/lib/autocanary24/client.rb
@@ -60,9 +60,7 @@ module AutoCanary24
 
       old_stack = stacks[:stack_to_create]
 
-      unless old_stack.nil?
-        delete_stack(old_stack.stack_name)
-      end
+      delete_stack(old_stack.stack_name)
     end
 
     private

--- a/spec/autocanary24_spec.rb
+++ b/spec/autocanary24_spec.rb
@@ -451,6 +451,38 @@ describe AutoCanary24::Client do
       end
     end
 
+    describe 'when blue stack is currently attached and green stack does not exist' do
+      let(:ac24) {AutoCanary24::Client.new({keep_inactive_stack: true})}
+
+      it 'should not clean the green stack' do
+        allow(blue_cs).to receive(:is_attached_to).with(elb).and_return(true)
+        allow(green_cs).to receive(:is_attached_to).with(elb).and_return(false)
+        allow(green_cs).to receive(:is_stack_created?).and_return(false)
+        allow(ac24).to receive(:get_stacks_to_create_and_to_delete).with(stack_name, elb).and_return(
+            {stack_to_create: green_cs, stack_to_delete: blue_cs})
+
+        expect(ac24).to receive(:delete_stack).with(green_cs.stack_name).exactly(0).times
+
+        ac24.cleanup_stack(stack_name)
+      end
+    end
+
+    describe 'when green stack is currently attached and blue stack does not exist' do
+      let(:ac24) {AutoCanary24::Client.new({keep_inactive_stack: true})}
+
+      it 'should not clean the blue stack' do
+        allow(green_cs).to receive(:is_attached_to).with(elb).and_return(true)
+        allow(blue_cs).to receive(:is_attached_to).with(elb).and_return(false)
+        allow(blue_cs).to receive(:is_stack_created?).and_return(false)
+        allow(ac24).to receive(:get_stacks_to_create_and_to_delete).with(stack_name, elb).and_return(
+            {stack_to_create: blue_cs, stack_to_delete: green_cs})
+
+        expect(ac24).to receive(:delete_stack).with(blue_cs.stack_name).exactly(0).times
+
+        ac24.cleanup_stack(stack_name)
+      end
+    end
+
   end
 
   context 'Rollback after unsuccessful health check' do
@@ -480,6 +512,40 @@ describe AutoCanary24::Client do
             {stack_to_create: blue_cs, stack_to_delete: green_cs})
 
         expect(blue_cs).to receive(:attach_asg_to_elb_and_wait).with(elb).exactly(1).times
+        expect(green_cs).to receive(:detach_asg_from_elb_and_wait).with(elb).exactly(1).times
+
+        ac24.rollback_stack(stack_name)
+      end
+    end
+
+    describe 'when blue stack is currently attached and green stack does not exist' do
+      let(:ac24) {AutoCanary24::Client.new({keep_inactive_stack: true})}
+
+      it 'should clean the blue stack and not reattach the green stack' do
+        allow(blue_cs).to receive(:is_attached_to).with(elb).and_return(true)
+        allow(green_cs).to receive(:is_attached_to).with(elb).and_return(false)
+        allow(green_cs).to receive(:is_stack_created?).and_return(false)
+        allow(ac24).to receive(:get_stacks_to_create_and_to_delete).with(stack_name, elb).and_return(
+            {stack_to_create: green_cs, stack_to_delete: blue_cs})
+
+        expect(green_cs).to receive(:attach_asg_to_elb_and_wait).with(elb).exactly(0).times
+        expect(blue_cs).to receive(:detach_asg_from_elb_and_wait).with(elb).exactly(1).times
+
+        ac24.rollback_stack(stack_name)
+      end
+    end
+
+    describe 'when green stack is currently attached and blue stack does not exist' do
+      let(:ac24) {AutoCanary24::Client.new({keep_inactive_stack: true})}
+
+      it 'should clean the blue stack and not reattach the green stack' do
+        allow(blue_cs).to receive(:is_attached_to).with(elb).and_return(false)
+        allow(green_cs).to receive(:is_attached_to).with(elb).and_return(true)
+        allow(blue_cs).to receive(:is_stack_created?).and_return(false)
+        allow(ac24).to receive(:get_stacks_to_create_and_to_delete).with(stack_name, elb).and_return(
+            {stack_to_create: blue_cs, stack_to_delete: green_cs})
+
+        expect(blue_cs).to receive(:attach_asg_to_elb_and_wait).with(elb).exactly(0).times
         expect(green_cs).to receive(:detach_asg_from_elb_and_wait).with(elb).exactly(1).times
 
         ac24.rollback_stack(stack_name)

--- a/spec/autocanary24_spec.rb
+++ b/spec/autocanary24_spec.rb
@@ -124,7 +124,7 @@ describe AutoCanary24::Client do
   context 'Switch (Blue/Green)' do
     before do
       stacks = {stack_to_create: green_cs, stack_to_delete: blue_cs}
-      allow(ac24).to receive(:get_stacks_to_create_and_to_delete_for).and_return(stacks)
+      allow(ac24).to receive(:determine_stacks_to_create_and_to_delete_for).and_return(stacks)
 
       allow(ac24).to receive(:before_switch)
       allow(ac24).to receive(:after_switch)
@@ -157,7 +157,7 @@ describe AutoCanary24::Client do
   context 'Canary deployment' do
     before do
       stacks = {stack_to_create: green_cs, stack_to_delete: blue_cs}
-      allow(ac24).to receive(:get_stacks_to_create_and_to_delete_for).and_return(stacks)
+      allow(ac24).to receive(:determine_stacks_to_create_and_to_delete_for).and_return(stacks)
 
       allow(ac24).to receive(:before_switch)
       allow(ac24).to receive(:after_switch)
@@ -259,7 +259,7 @@ describe AutoCanary24::Client do
   context 'After switch' do
     before do
       stacks = {stack_to_create: green_cs, stack_to_delete: blue_cs}
-      allow(ac24).to receive(:get_stacks_to_create_and_to_delete_for).and_return(stacks)
+      allow(ac24).to receive(:determine_stacks_to_create_and_to_delete_for).and_return(stacks)
 
       allow(ac24).to receive(:before_switch)
       allow(ac24).to receive(:switch)
@@ -291,7 +291,7 @@ describe AutoCanary24::Client do
   context 'Rollback' do
     before do
       stacks = {stack_to_create: green_cs, stack_to_delete: blue_cs}
-      allow(ac24).to receive(:get_stacks_to_create_and_to_delete_for).and_return(stacks)
+      allow(ac24).to receive(:determine_stacks_to_create_and_to_delete_for).and_return(stacks)
 
       allow(ac24).to receive(:before_switch)
 
@@ -416,6 +416,73 @@ describe AutoCanary24::Client do
         expect {
           ac24.deploy_stack(stack_name, template, parameters, tags, deployment_check)
         }.to raise_error("Deployment failed because of rollback")
+      end
+    end
+  end
+
+  context 'Cleanup after successful health check' do
+    describe 'when blue stack is currently attached and green stack is detached and kept inactive' do
+      let(:ac24) {AutoCanary24::Client.new({keep_inactive_stack: true})}
+
+      it 'should clean the green stack' do
+        allow(blue_cs).to receive(:is_attached_to).with(elb).and_return(true)
+        allow(green_cs).to receive(:is_attached_to).with(elb).and_return(false)
+        allow(ac24).to receive(:get_stacks_to_create_and_to_delete).with(stack_name, elb).and_return(
+            {stack_to_create: green_cs, stack_to_delete: blue_cs})
+
+        expect(ac24).to receive(:delete_stack).with(green_cs.stack_name).exactly(1).times
+
+        ac24.cleanup_stack(stack_name)
+      end
+    end
+
+    describe 'when green stack is currently attached and blue stack is detached and kept inactive' do
+      let(:ac24) {AutoCanary24::Client.new({keep_inactive_stack: true})}
+
+      it 'should clean the blue stack' do
+        allow(green_cs).to receive(:is_attached_to).with(elb).and_return(true)
+        allow(blue_cs).to receive(:is_attached_to).with(elb).and_return(false)
+        allow(ac24).to receive(:get_stacks_to_create_and_to_delete).with(stack_name, elb).and_return(
+            {stack_to_create: blue_cs, stack_to_delete: green_cs})
+
+        expect(ac24).to receive(:delete_stack).with(blue_cs.stack_name).exactly(1).times
+
+        ac24.cleanup_stack(stack_name)
+      end
+    end
+
+  end
+
+  context 'Rollback after unsuccessful health check' do
+    describe 'when blue stack is currently attached and green stack is detached and kept inactive' do
+      let(:ac24) {AutoCanary24::Client.new({keep_inactive_stack: true})}
+
+      it 'should clean the blue stack and reattach the green stack' do
+        allow(blue_cs).to receive(:is_attached_to).with(elb).and_return(true)
+        allow(green_cs).to receive(:is_attached_to).with(elb).and_return(false)
+        allow(ac24).to receive(:get_stacks_to_create_and_to_delete).with(stack_name, elb).and_return(
+            {stack_to_create: green_cs, stack_to_delete: blue_cs})
+
+        expect(green_cs).to receive(:attach_asg_to_elb_and_wait).with(elb).exactly(1).times
+        expect(blue_cs).to receive(:detach_asg_from_elb_and_wait).with(elb).exactly(1).times
+
+        ac24.rollback_stack(stack_name)
+      end
+    end
+
+    describe 'when green stack is currently attached and blue stack is detached and kept inactive' do
+      let(:ac24) {AutoCanary24::Client.new({keep_inactive_stack: true})}
+
+      it 'should clean the blue stack and reattach the green stack' do
+        allow(blue_cs).to receive(:is_attached_to).with(elb).and_return(false)
+        allow(green_cs).to receive(:is_attached_to).with(elb).and_return(true)
+        allow(ac24).to receive(:get_stacks_to_create_and_to_delete).with(stack_name, elb).and_return(
+            {stack_to_create: blue_cs, stack_to_delete: green_cs})
+
+        expect(blue_cs).to receive(:attach_asg_to_elb_and_wait).with(elb).exactly(1).times
+        expect(green_cs).to receive(:detach_asg_from_elb_and_wait).with(elb).exactly(1).times
+
+        ac24.rollback_stack(stack_name)
       end
     end
   end

--- a/spec/canarystack_spec.rb
+++ b/spec/canarystack_spec.rb
@@ -40,5 +40,24 @@ describe AutoCanary24::CanaryStack do
 
         expect(stack.is_attached_to(elb_name)).to equal(false)
       end
-  end
+    end
+
+    context 'isStackCreated?' do
+      describe 'when a stack is not created' do
+        it 'should return false' do
+          stack = AutoCanary24::CanaryStack.new('mystack-B', 300)
+
+          expect(stack.is_stack_created?).to equal(false)
+        end
+      end
+
+      describe 'when a stack is created' do
+        it 'should return true' do
+          stack = AutoCanary24::CanaryStack.new('mystack-B', 300)
+          allow(stack).to receive(:get_instance_ids)
+
+          expect(stack.is_stack_created?).to equal(true)
+        end
+      end
+    end
 end

--- a/spec/canarystack_spec.rb
+++ b/spec/canarystack_spec.rb
@@ -1,0 +1,44 @@
+require 'spec_helper'
+
+describe AutoCanary24::CanaryStack do
+
+    elb_name = "ELB-123"
+
+    ElbStub = Struct.new(:state_name, :name) do
+      def state
+        state_name
+      end
+
+      def load_balancer_name
+        name
+      end
+    end
+
+    describe 'when elb is in "Removed" state' do
+      it 'should not be attached to elb' do
+        elb = ElbStub.new("Removed", elb_name)
+        autoscaling_group_stub = Class.new
+
+        stack = AutoCanary24::CanaryStack.new('mystack-B', 300)
+
+        allow(stack).to receive(:get_autoscaling_group).and_return(autoscaling_group_stub)
+        allow(stack).to receive(:get_attached_loadbalancers).and_return([elb])
+
+        expect(stack.is_attached_to(elb_name)).to equal(false)
+      end
+    end
+
+    describe 'when elb is in "Removing" state' do
+      it 'should not be attached to elb' do
+        elb = ElbStub.new("Removing", elb_name)
+        autoscaling_group_stub = Class.new
+
+        stack = AutoCanary24::CanaryStack.new('mystack-B', 300)
+
+        allow(stack).to receive(:get_autoscaling_group).and_return(autoscaling_group_stub)
+        allow(stack).to receive(:get_attached_loadbalancers).and_return([elb])
+
+        expect(stack.is_attached_to(elb_name)).to equal(false)
+      end
+  end
+end


### PR DESCRIPTION
So far, AutoCanary runs the health check on both the new and old Autoscalinggroups (ASG). Which means just 50% chance of spotting issues on the new ASG.

What we actually want is that the health check runs only on the newly created ASG, and if it fails rollback, otherwise cleanup the old ASG.

After talking to @pgarbe about possible solutions, we decided to expose two new methods on the AutoCanary client for rolling back or cleaning up. This way we stay backwards compatible. How to use these methods can be seen in the [examples](https://github.com/MatteoDiTucciTW/autocanary24/blob/master/examples/Rakefile#L79-L117)