### PR TITLE
Update rake sample to raise an exception if the health check fails

### DIFF
--- a/examples/Rakefile
+++ b/examples/Rakefile
@@ -93,6 +93,7 @@ task :sample_5 do
     client.cleanup_stack(STACK_NAME)
   else
     client.rollback_stack(STACK_NAME)
+    raise "Deployment failed because of health check"
   end
 end
 


### PR DESCRIPTION
We wanted to make explicit in the documentation that if a failing health check is executed outside the AutoCanary Client, then the deployment won't fail. In this scenario, an exception has to be raised from the client calling the AutoCanary Client.
To represent a more realistic use case, we have updated the example to do both rollback and raise an exception if this happens.