### PR TITLE
:arrow_up: Upgrade to aws sdk v3

### DIFF
--- a/autocanary24.gemspec
+++ b/autocanary24.gemspec
@@ -20,7 +20,8 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency 'autostacker24', '~> 2'
-  spec.add_dependency 'aws-sdk-core', '~> 2'
+  spec.add_dependency 'aws-sdk-core', '~> 3'
+  spec.add_dependency 'aws-sdk-elasticloadbalancing', '~> 1.2'
 
   spec.add_development_dependency "bundler", "~> 1.11"
   spec.add_development_dependency "rake", "~> 10.0"

--- a/lib/autocanary24/canarystack.rb
+++ b/lib/autocanary24/canarystack.rb
@@ -1,4 +1,5 @@
 require 'aws-sdk-core'
+require 'aws-sdk-elasticloadbalancing'
 
 module AutoCanary24
   class CanaryStack


### PR DESCRIPTION
Makes the aws sdk dependencies compatible with latest Autostacker24 gem.