### PR TITLE
:back: Back-off Retry for AWS API 'Rate Exceeded' Errors

### DIFF
--- a/autocanary24.gemspec
+++ b/autocanary24.gemspec
@@ -21,6 +21,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency 'autostacker24', '~> 2'
   spec.add_dependency 'aws-sdk-core', '~> 2'
+  spec.add_dependency 'retriable', '~> 3.1'
 
   spec.add_development_dependency "bundler", "~> 1.11"
   spec.add_development_dependency "rake", "~> 10.0"

--- a/lib/autocanary24/version.rb
+++ b/lib/autocanary24/version.rb
@@ -1,3 +1,3 @@
 module AutoCanary24
-  VERSION = "0.5.0"
+  VERSION = "0.6.0"
 end

--- a/spec/service/canarystack24_service_spec.rb
+++ b/spec/service/canarystack24_service_spec.rb
@@ -1,0 +1,56 @@
+require 'spec_helper'
+
+describe AutoCanary24::CanaryStack do
+  elb_name = "ELB-123"
+  
+  before do
+    @instances =
+      [{instance_id: "i-123",}]
+    @instance_responses = {
+      instance_states: [
+        {
+          description: "N/A", 
+          instance_id: "i-207d9717", 
+          reason_code: "N/A", 
+          state: "NotInService", 
+        }, 
+        {
+          description: "N/A", 
+          instance_id: "i-afefb49b", 
+          reason_code: "N/A", 
+          state: "NotInService", 
+        }, 
+      ], 
+    }
+    @elb_client = Aws::ElasticLoadBalancing::Client.new(stub_responses: true)
+    allow(Aws::ElasticLoadBalancing::Client).to receive(:new).and_return(@elb_client)
+  end
+  
+  describe 'when AWS API returns Aws::CloudFormation::Errors::Throttling "Rate Exceeded" exception' do
+    it 'should back off and retry' do
+      @elb_client.stub_responses(:describe_instance_health,
+        Aws::CloudFormation::Errors::Throttling.new("First parm", "Rate Exceeded"),
+        Aws::CloudFormation::Errors::Throttling.new("First parm", "Rate Exceeded"),
+        @instance_responses
+      )
+
+      stack = AutoCanary24::CanaryStack.new('mystack-B', 300)
+
+      expect(stack.send(:wait_for_instances_detached_from_elb, @instances, elb_name)).to eq nil
+    end
+
+    it 'should raise exception after 5 throttling errors' do
+      @elb_client.stub_responses(:describe_instance_health,
+        Aws::CloudFormation::Errors::Throttling.new("First parm", "Rate Exceeded"),
+        # Aws::CloudFormation::Errors::Throttling.new("First parm", "Rate Exceeded"),
+        # Aws::CloudFormation::Errors::Throttling.new("First parm", "Rate Exceeded"),
+        # Aws::CloudFormation::Errors::Throttling.new("First parm", "Rate Exceeded"),
+        # Aws::CloudFormation::Errors::Throttling.new("First parm", "Rate Exceeded"),
+      )
+
+      stack = AutoCanary24::CanaryStack.new('mystack-B', 300)
+    
+      expect(stack.send(:wait_for_instances_detached_from_elb, @instances, elb_name)).to raise_exception(Aws::CloudFormation::Errors::Throttling)
+    end
+  end
+end


### PR DESCRIPTION
To address https://github.com/Scout24/autocanary24/issues/13
Assumes merge of https://github.com/Scout24/autocanary24/pull/18

Let me know if you'd rather it prior to or without the aws sdk v3 upgrade.